### PR TITLE
Add MinVer support and NuGet publishing workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - "feature"
+        - "enhancement"
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "bug"
+        - "fix"
+    - title: "🔧 Maintenance"
+      labels:
+        - "maintenance"
+    - title: "📚 Documentation"
+      labels:
+        - "documentation"
+    - title: "🚨 Breaking Changes"
+      labels:
+        - "breaking"
+    - title: "🧹 Chore"
+      labels:
+        - "chore"
+    - title: "🚩 Other"
+      labels:
+        - "other"
+    - title: "🚦 CI/CD"
+      labels:
+        - "ci/cd"
+    - title: "🔍 Tests"
+      labels:
+        - "test"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET
+name: .NET Build and Test
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: .NET Pack and Publish Tool
+
+on: 
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish_nuget_package:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Package NuGet package
+        run: dotnet pack -c Release
+      - name: Publish NuGet package
+        run: |
+          dotnet nuget push ./bin/Release/*.nupkg 
+          --api-key ${{ secrets.NUGET_API_KEY }} 
+          --source https://api.nuget.org/v3/index.json
+      

--- a/src/DotUML.CLI/DotUML.CLI.csproj
+++ b/src/DotUML.CLI/DotUML.CLI.csproj
@@ -10,6 +10,11 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="ConsoleAppFramework" Version="5.4.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -19,6 +24,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="ZLogger" Version="2.5.10" />
   </ItemGroup>
 


### PR DESCRIPTION
Introduce MinVer configuration for versioning, along with a new workflow for packaging and publishing NuGet packages. Update existing workflow names for clarity.