### PR TITLE
Add workflow steps for packaging and publishing alpha NuGet package

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,3 +28,14 @@ jobs:
 
     - name: Run tests
       run: dotnet test --no-build --verbosity normal
+
+    - name: Package alpha NuGet package
+      if: github.ref == 'refs/heads/main'
+      run: dotnet pack -c Release -o nupkg
+      
+    - name: Publish alpha NuGet package
+      if: github.ref == 'refs/heads/main'
+      env:
+        API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: |
+        dotnet nuget push ./nupkg/*.nupkg --api-key $API_KEY --source 'https://api.nuget.org/v3/index.json'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,5 +26,3 @@ jobs:
           API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           dotnet nuget push ./nupkg/*.nupkg --api-key $API_KEY --source 'https://api.nuget.org/v3/index.json'
-      
-


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to automate the packaging and publishing of an alpha NuGet package when changes are pushed to the `main` branch.

### Automation of NuGet package management:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R31-R41): Added steps to package and publish an alpha NuGet package when changes are pushed to the `main` branch.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L29-L30): Removed unnecessary blank lines to clean up the workflow file.