### PR TITLE
Refactor diagram generation to support multiple output types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ or
 dotuml generate --solution C:\source\repos\Solution\Awesome.sln
 ```
 
+The following options are available on the method.
+
+
+| Option                  | Description                                                                                                                                               |
+|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-s` `--solution`       | Solution to analyze and generate UML diagram for. (Required)                                                                                              |
+| `-f` `--format`         | Output type for the diagram. Options: markdown, image (Default: Markdown)                                                                                  |
+| `-o` `--output-file`    | Target location for UML file output. If a location is not provided, then a filename including a timestamp will be created in the current directory. (Default: `@"diagramyyyyMMddHHmmss.md"`) |
+
 ### Contributing
 Contributions are welcome! Please fork the repository and submit a pull request.
 

--- a/src/DotUML.CLI/Diagram/Models.cs
+++ b/src/DotUML.CLI/Diagram/Models.cs
@@ -195,6 +195,39 @@ public class Namespaces : IGrouping<string, NamespaceInfo>
         }
     }
 
+    public string GetUMLDiagram()
+    {
+        var sb = new IndentedStringBuilder();
+        foreach (var ns in this)
+        {
+            if (!string.IsNullOrEmpty(ns.Name))
+            {
+                sb.AppendLine($"namespace {ns.Name} {{");
+                sb.IncreaseIndent();
+            }
+
+            foreach (var obj in ns.ObjectInfos)
+            {
+                sb.Append(obj.GetObjectRepresentation().Trim());
+            }
+
+            if (!string.IsNullOrEmpty(ns.Name))
+            {
+                sb.DecreaseIndent();
+                sb.AppendLine("}");
+            }
+        }
+
+        foreach (var obj in this.SelectMany(ns => ns.ObjectInfos.OfType<IHaveRelationships>()))
+        {
+            if (!string.IsNullOrWhiteSpace(obj.GetRelationshipRepresentation()))
+            {
+                sb.Append(obj.GetRelationshipRepresentation().Trim());
+            }
+        }
+        return sb.ToString();
+    }
+
     public string Key { get; }
 
     public IEnumerator<NamespaceInfo> GetEnumerator() => _namespaces.GetEnumerator();

--- a/src/DotUML.CLI/GenerateCommands.cs
+++ b/src/DotUML.CLI/GenerateCommands.cs
@@ -33,6 +33,6 @@ public class GenerateCommands
         }
         var classes = await _classAnalyzer.ExtractClassesFromSolutionAsync(solution);
         var diagram = _classDiagramGenerator.GenerateDiagram(classes);
-        _classDiagramGenerator.WriteToReadme(outputFile, diagram);
+        _classDiagramGenerator.WriteToFile(outputFile, diagram);
     }
 }

--- a/src/DotUML.CLI/GenerateCommands.cs
+++ b/src/DotUML.CLI/GenerateCommands.cs
@@ -16,23 +16,24 @@ public partial class GenerateCommands
         _diagramGenerators = diagramGenerators;
     }
 
+    public const string DefaultOutputFileName = "diagramyyyyMMddHHmmss.md";
     /// <summary>
     /// Generate a class diagram from a solution and write it to a file.
     /// </summary>
     /// <param name="solution">-s, Solution to analyze and generate UML diagram for.</param>
     /// <param name="outputFile">-o, Target location for UML file output.</param>
-    /// <param name="outputType">-t, Output type for the diagram. Options: Markdown, Image</param>
-    public async Task Generate(string solution, string? outputFile = "", OutputType outputType = OutputType.Image)
+    /// <param name="format">-f, Output type for the diagram. Options: markdown, image</param>
+    public async Task Generate(string solution, OutputType format = OutputType.Markdown, string? outputFile = DefaultOutputFileName)
     {
         if (string.IsNullOrEmpty(solution))
         {
             Console.WriteLine("Please provide a solution path.");
             return;
         }
-        if (string.IsNullOrEmpty(outputFile))
+        if (string.IsNullOrEmpty(outputFile) || outputFile == DefaultOutputFileName)
         {
             string timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");
-            var extension = outputType switch
+            var extension = format switch
             {
                 OutputType.Markdown => "md",
                 OutputType.Image => "png",
@@ -40,7 +41,7 @@ public partial class GenerateCommands
             };
             outputFile = $"diagram{timestamp}.{extension}";
         }
-        var mermaidDiagramGenerator = _diagramGenerators.FirstOrDefault(g => g.OutputType == outputType);
+        var mermaidDiagramGenerator = _diagramGenerators.FirstOrDefault(g => g.OutputType == format);
         if (mermaidDiagramGenerator == null)
         {
             throw new ArgumentException("Invalid output type.");

--- a/src/DotUML.CLI/GenerateCommands.cs
+++ b/src/DotUML.CLI/GenerateCommands.cs
@@ -21,7 +21,7 @@ public partial class GenerateCommands
     /// Generate a class diagram from a solution and write it to a file.
     /// </summary>
     /// <param name="solution">-s, Solution to analyze and generate UML diagram for.</param>
-    /// <param name="outputFile">-o, Target location for UML file output.</param>
+    /// <param name="outputFile">-o, Target location for UML file output. If a location is not provided, then a filename including a timestamp will be created in the current directory.</param>
     /// <param name="format">-f, Output type for the diagram. Options: markdown, image</param>
     public async Task Generate(string solution, OutputType format = OutputType.Markdown, string? outputFile = DefaultOutputFileName)
     {

--- a/src/DotUML.CLI/Mermaid/ClassDiagramGenerator.cs
+++ b/src/DotUML.CLI/Mermaid/ClassDiagramGenerator.cs
@@ -21,41 +21,14 @@ public class ClassDiagramGenerator
         diagram.AppendLine("classDiagram");
         diagram.IncreaseIndent();
 
-        foreach (var ns in namespaces)
-        {
-            if (!string.IsNullOrEmpty(ns.Name))
-            {
-                diagram.AppendLine($"namespace {ns.Name} {{");
-                diagram.IncreaseIndent();
-            }
-
-            foreach (var obj in ns.ObjectInfos)
-            {
-                diagram.Append(obj.GetObjectRepresentation().Trim());
-            }
-
-            if (!string.IsNullOrEmpty(ns.Name))
-            {
-                diagram.DecreaseIndent();
-                diagram.AppendLine("}");
-            }
-        }
-
-
-        foreach (var obj in namespaces.SelectMany(ns => ns.ObjectInfos.OfType<IHaveRelationships>()))
-        {
-            if (!string.IsNullOrWhiteSpace(obj.GetRelationshipRepresentation()))
-            {
-                diagram.Append(obj.GetRelationshipRepresentation().Trim());
-            }
-        }
+        diagram.Append(namespaces.GetUMLDiagram());
 
         diagram.DecreaseIndent();
         diagram.AppendLine("```");
         return diagram.ToString();
     }
 
-    public void WriteToReadme(string outputPath, string content)
+    public void WriteToFile(string outputPath, string content)
     {
         File.WriteAllText(outputPath, content);
         _logger.LogCritical($"Mermaid UML diagram written to {outputPath}");

--- a/src/DotUML.CLI/Mermaid/IGenerateMermaidDiagram.cs
+++ b/src/DotUML.CLI/Mermaid/IGenerateMermaidDiagram.cs
@@ -1,0 +1,13 @@
+using DotUML.CLI.Diagram;
+
+using static DotUML.CLI.GenerateCommands;
+
+
+namespace DotUML.CLI.Mermaid;
+
+public interface IGenerateMermaidDiagram
+{
+    string GenerateDiagram(Namespaces namespaces);
+    Task WriteToFile(string outputPath, string content);
+    public OutputType OutputType { get; }
+}

--- a/src/DotUML.CLI/Mermaid/ImageDiagramGenerator.cs
+++ b/src/DotUML.CLI/Mermaid/ImageDiagramGenerator.cs
@@ -1,0 +1,100 @@
+using System.Formats.Asn1;
+using System.IO.Compression;
+using System.Text;
+using System.Threading.Tasks;
+
+using DotUML.CLI.Diagram;
+using DotUML.CLI.Text;
+
+using Microsoft.Extensions.Logging;
+
+namespace DotUML.CLI.Mermaid;
+
+public class ImageDiagramGenerator : IGenerateMermaidDiagram
+{
+    private readonly ILogger<ImageDiagramGenerator> _logger;
+
+    public ImageDiagramGenerator(ILogger<ImageDiagramGenerator> logger)
+    {
+        _logger = logger;
+    }
+
+    public OutputType OutputType => OutputType.Image;
+
+    public string GenerateDiagram(Namespaces namespaces)
+    {
+        var diagram = $"classDiagram{Environment.NewLine}";
+        diagram += namespaces.GetUMLDiagram();
+        var compressedBytes = Deflate(Encoding.UTF8.GetBytes(diagram));
+        var encodedOutput = Convert.ToBase64String(compressedBytes).Replace('+', '-').Replace('/', '_');
+        var imageUrl = $"https://kroki.io/mermaid/png/{encodedOutput}";
+        return imageUrl;
+    }
+
+    private static byte[] Deflate(byte[] data, CompressionLevel? level = null)
+    {
+        byte[] newData;
+        using (var memStream = new MemoryStream())
+        {
+            // write header:
+            memStream.WriteByte(0x78);
+            switch (level)
+            {
+                case CompressionLevel.NoCompression:
+                case CompressionLevel.Fastest:
+                    memStream.WriteByte(0x01);
+                    break;
+                case CompressionLevel.Optimal:
+                    memStream.WriteByte(0xDA);
+                    break;
+                default:
+                    memStream.WriteByte(0x9C);
+                    break;
+            }
+
+            // write compressed data (with Deflate headers):
+            using (var dflStream = level.HasValue
+                       ? new DeflateStream(memStream, level.Value)
+                       : new DeflateStream(memStream, CompressionMode.Compress
+                       )) dflStream.Write(data, 0, data.Length);
+            //
+            newData = memStream.ToArray();
+        }
+
+        // compute Adler-32:
+        uint a1 = 1, a2 = 0;
+        foreach (byte b in data)
+        {
+            a1 = (a1 + b) % 65521;
+            a2 = (a2 + a1) % 65521;
+        }
+
+        // append the checksum-trailer:
+        var adlerPos = newData.Length;
+        Array.Resize(ref newData, adlerPos + 4);
+        newData[adlerPos] = (byte)(a2 >> 8);
+        newData[adlerPos + 1] = (byte)a2;
+        newData[adlerPos + 2] = (byte)(a1 >> 8);
+        newData[adlerPos + 3] = (byte)a1;
+        return newData;
+    }
+
+    public async Task WriteToFile(string outputPath, string content)
+    {
+        try
+        {
+            using (var client = new HttpClient())
+            {
+                var response = client.GetAsync(content).Result;
+                response.EnsureSuccessStatusCode();
+                var imageBytes = response.Content.ReadAsByteArrayAsync().Result;
+                await File.WriteAllBytesAsync(outputPath, imageBytes);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while writing the diagram to file.");
+            throw;
+        }
+    }
+}

--- a/src/DotUML.CLI/Mermaid/MarkdownDiagramGenerator.cs
+++ b/src/DotUML.CLI/Mermaid/MarkdownDiagramGenerator.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 using DotUML.CLI.Diagram;
 using DotUML.CLI.Text;
 
@@ -5,14 +7,16 @@ using Microsoft.Extensions.Logging;
 
 namespace DotUML.CLI.Mermaid;
 
-public class ClassDiagramGenerator
+public class MarkdownDiagramGenerator : IGenerateMermaidDiagram
 {
-    private readonly ILogger<ClassDiagramGenerator> _logger;
+    private readonly ILogger<MarkdownDiagramGenerator> _logger;
 
-    public ClassDiagramGenerator(ILogger<ClassDiagramGenerator> logger)
+    public MarkdownDiagramGenerator(ILogger<MarkdownDiagramGenerator> logger)
     {
         _logger = logger;
     }
+
+    public OutputType OutputType => OutputType.Markdown;
 
     public string GenerateDiagram(Namespaces namespaces)
     {
@@ -28,9 +32,9 @@ public class ClassDiagramGenerator
         return diagram.ToString();
     }
 
-    public void WriteToFile(string outputPath, string content)
+    public async Task WriteToFile(string outputPath, string content)
     {
-        File.WriteAllText(outputPath, content);
+        await File.WriteAllTextAsync(outputPath, content);
         _logger.LogCritical($"Mermaid UML diagram written to {outputPath}");
     }
 }

--- a/src/DotUML.CLI/Mermaid/OutputType.cs
+++ b/src/DotUML.CLI/Mermaid/OutputType.cs
@@ -1,0 +1,8 @@
+namespace DotUML.CLI.Mermaid;
+
+public enum OutputType
+{
+    Markdown,
+    Image
+}
+

--- a/src/DotUML.CLI/Program.cs
+++ b/src/DotUML.CLI/Program.cs
@@ -18,7 +18,8 @@ app
     .ConfigureServices((services) =>
     {
         services.AddTransient<ClassAnalyzer>();
-        services.AddTransient<ClassDiagramGenerator>();
+        services.AddTransient<IGenerateMermaidDiagram, MarkdownDiagramGenerator>();
+        services.AddTransient<IGenerateMermaidDiagram, ImageDiagramGenerator>();
     });
 
 

--- a/tests/DotUML.Tests/GenerateCommandsTests.cs
+++ b/tests/DotUML.Tests/GenerateCommandsTests.cs
@@ -45,7 +45,7 @@ namespace DotUML.Tests.Tests
             Console.WriteLine($"Solution Path: {solution}");
             Console.WriteLine($"Base Directory: {baseDirectory}");
             // Act
-            await _generateCommands.Generate(solution, outputPath, OutputType.Markdown);
+            await _generateCommands.Generate(solution, OutputType.Markdown, outputPath);
 
             // Assert
             Assert.True(File.Exists(outputPath));
@@ -64,7 +64,7 @@ namespace DotUML.Tests.Tests
             Console.WriteLine($"Solution Path: {solution}");
             Console.WriteLine($"Base Directory: {baseDirectory}");
             // Act
-            await _generateCommands.Generate(solution, outputPath, OutputType.Image);
+            await _generateCommands.Generate(solution, OutputType.Image, outputPath);
 
             // Assert
             Assert.True(File.Exists(outputPath));

--- a/tests/DotUML.Tests/GenerateCommandsTests.cs
+++ b/tests/DotUML.Tests/GenerateCommandsTests.cs
@@ -15,22 +15,27 @@ namespace DotUML.Tests.Tests
     {
         private readonly ILogger<ClassAnalyzer> _classAnalyzerLogger;
         private readonly ClassAnalyzer _classAnalyzer;
-        private readonly ILogger<ClassDiagramGenerator> _classDiagramGeneratorLogger;
-        private readonly ClassDiagramGenerator _classDiagramGenerator;
+        private readonly ILogger<MarkdownDiagramGenerator> _classDiagramGeneratorLogger;
+        private readonly MarkdownDiagramGenerator _classDiagramGenerator;
+        private readonly ILogger<ImageDiagramGenerator> _imageDiagramGeneratorLogger;
+        private readonly ImageDiagramGenerator _imageDiagramGenerator;
+        private readonly GenerateCommands _generateCommands;
 
         public GenerateCommandsTestsTest()
         {
             _classAnalyzerLogger = Substitute.For<ILogger<ClassAnalyzer>>();
             _classAnalyzer = new ClassAnalyzer(_classAnalyzerLogger);
-            _classDiagramGeneratorLogger = Substitute.For<ILogger<ClassDiagramGenerator>>();
-            _classDiagramGenerator = new ClassDiagramGenerator(_classDiagramGeneratorLogger);
+            _classDiagramGeneratorLogger = Substitute.For<ILogger<MarkdownDiagramGenerator>>();
+            _classDiagramGenerator = new MarkdownDiagramGenerator(_classDiagramGeneratorLogger);
+            _imageDiagramGeneratorLogger = Substitute.For<ILogger<ImageDiagramGenerator>>();
+            _imageDiagramGenerator = new ImageDiagramGenerator(_imageDiagramGeneratorLogger);
+            _generateCommands = new GenerateCommands(_classAnalyzer, [_classDiagramGenerator, _imageDiagramGenerator]);
         }
 
         [Fact]
-        public async Task GenerateCommands_ShouldCreateFile()
+        public async Task GenerateCommands_ShouldCreateMarkdownFile()
         {
             // Arrange
-            var generateCommands = new GenerateCommands(_classAnalyzer, _classDiagramGenerator);
             var outputPath = Path.Combine(Path.GetTempPath(), "diagram.md");
             var baseDirectory = AppContext.BaseDirectory;
             Console.WriteLine($"Base Directory: {baseDirectory}");
@@ -40,7 +45,26 @@ namespace DotUML.Tests.Tests
             Console.WriteLine($"Solution Path: {solution}");
             Console.WriteLine($"Base Directory: {baseDirectory}");
             // Act
-            await generateCommands.Generate(solution, outputPath);
+            await _generateCommands.Generate(solution, outputPath, OutputType.Markdown);
+
+            // Assert
+            Assert.True(File.Exists(outputPath));
+        }
+
+        [Fact]
+        public async Task GenerateCommands_ShouldCreatePngFile()
+        {
+            // Arrange
+            var outputPath = Path.Combine(Path.GetTempPath(), "diagram.png");
+            var baseDirectory = AppContext.BaseDirectory;
+            Console.WriteLine($"Base Directory: {baseDirectory}");
+
+            var solution = Path.Combine(baseDirectory, @"..", "..", "..", "..", "..", "test-solutions", "SampleWeb.sln");
+            solution = Path.GetFullPath(solution);
+            Console.WriteLine($"Solution Path: {solution}");
+            Console.WriteLine($"Base Directory: {baseDirectory}");
+            // Act
+            await _generateCommands.Generate(solution, outputPath, OutputType.Image);
 
             // Assert
             Assert.True(File.Exists(outputPath));


### PR DESCRIPTION
Refactor UML string building and implement support for generating diagrams in both Markdown and Image formats. This change enhances flexibility in diagram output options.

Closes #21