### PR TITLE
Use sanitized names in object representation and add unit tests for ClassInfo

### DIFF
--- a/src/DotUML.CLI/Diagram/Models.cs
+++ b/src/DotUML.CLI/Diagram/Models.cs
@@ -73,6 +73,7 @@ public interface IHaveRelationships
 
 public abstract record ObjectInfo(string Name)
 {
+    public string SanitizedName => Name.Replace('<', '~').Replace('>', '~');
     protected List<PropertyInfo> _properties = new();
     protected List<MethodInfo> _methods = new();
     public abstract string GetObjectRepresentation();
@@ -87,7 +88,7 @@ public record EnumInfo(string Name) : ObjectInfo(Name)
     public override string GetObjectRepresentation()
     {
         var sb = new IndentedStringBuilder();
-        sb.AppendLine($"class {Name} {{");
+        sb.AppendLine($"class {SanitizedName} {{");
         sb.IncreaseIndent();
         sb.AppendLine("<<enumeration>>");
         sb.AppendJoin("", _values.Select(p => p));
@@ -108,7 +109,7 @@ public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
     public override string GetObjectRepresentation()
     {
         var sb = new IndentedStringBuilder();
-        sb.AppendLine($"class {Name} {{");
+        sb.AppendLine($"class {SanitizedName} {{");
         sb.IncreaseIndent();
         sb.AppendJoin(string.Empty, _properties.Select(p => p.GetDiagramRepresentation()));
         sb.AppendJoin(string.Empty, _methods.Select(m => m.GetDiagramRepresentation()));
@@ -120,13 +121,13 @@ public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
     public string GetRelationshipRepresentation()
     {
         var sb = new IndentedStringBuilder();
-        sb.AppendJoin(string.Empty, _dependencies.Select(d => $"{Name} ..> {d.Type.SanitizedName}"));
-        sb.AppendJoin(string.Empty, _interfaces.Select(i => $"{i} <|.. {Name}"));
+        sb.AppendJoin(string.Empty, _dependencies.Select(d => $"{SanitizedName} ..> {d.Type.SanitizedName}"));
+        sb.AppendJoin(string.Empty, _interfaces.Select(i => $"{i} <|.. {SanitizedName}"));
         if (!string.IsNullOrEmpty(BaseClass))
         {
-            sb.AppendLine($"{BaseClass} <|-- {Name}");
+            sb.AppendLine($"{BaseClass} <|-- {SanitizedName}");
         }
-        sb.AppendJoin(string.Empty, _properties.Select(p => p.GetRelationshipRepresentation(Name)));
+        sb.AppendJoin(string.Empty, _properties.Select(p => p.GetRelationshipRepresentation(SanitizedName)));
         return sb.ToString();
     }
 
@@ -152,7 +153,7 @@ public record InterfaceInfo(string Name) : ObjectInfo(Name), IHaveRelationships
     public override string GetObjectRepresentation()
     {
         var sb = new IndentedStringBuilder();
-        sb.AppendLine($"class {Name} {{");
+        sb.AppendLine($"class {SanitizedName} {{");
         sb.IncreaseIndent();
         sb.AppendLine("<<interface>>");
         sb.AppendJoin(string.Empty, _properties.Select(p => p.GetDiagramRepresentation()));
@@ -165,7 +166,7 @@ public record InterfaceInfo(string Name) : ObjectInfo(Name), IHaveRelationships
     public string GetRelationshipRepresentation()
     {
         var sb = new IndentedStringBuilder();
-        sb.AppendJoin(string.Empty, _properties.Select(p => p.GetRelationshipRepresentation(Name)));
+        sb.AppendJoin(string.Empty, _properties.Select(p => p.GetRelationshipRepresentation(SanitizedName)));
         return sb.ToString();
     }
 }

--- a/tests/DotUML.Tests/Models/ClassInfoTests.cs
+++ b/tests/DotUML.Tests/Models/ClassInfoTests.cs
@@ -1,0 +1,23 @@
+using System;
+
+using DotUML.CLI.Diagram;
+
+using Xunit;
+
+namespace DotUML.Tests.Models;
+
+public class ClassInfoTests
+{
+    [Fact]
+    public void Test1()
+    {
+        // Arrange
+        var classInfo = new ClassInfo("Class<Generic>");
+
+        // Act
+        var result = classInfo.GetObjectRepresentation();
+
+        // Assert
+        Assert.True(result.StartsWith("class Class~Generic~"));
+    }
+}


### PR DESCRIPTION
Implement sanitized names to prevent invalid characters in object representations and add unit tests to validate the functionality of ClassInfo.

Closes #25