### PR TITLE
Fix base class

### DIFF
--- a/src/DotUML.CLI/Analyzers/ClassAnalyzer.cs
+++ b/src/DotUML.CLI/Analyzers/ClassAnalyzer.cs
@@ -134,7 +134,7 @@ public class ClassAnalyzer
         ;
     }
 
-    private IEnumerable<ObjectInfo> AnalyzeRecords(SyntaxNode root, SemanticModel semanticModel)
+    private IEnumerable<ClassInfo> AnalyzeRecords(SyntaxNode root, SemanticModel semanticModel)
     {
         foreach (var recordNode in root.DescendantNodes().OfType<RecordDeclarationSyntax>())
         {
@@ -147,10 +147,8 @@ public class ClassAnalyzer
             string className = recordNode.Identifier.Text;
             var baseRecords = recordNode.BaseList?.Types.OfType<BaseTypeSyntax>();
             var recordInfo = new ClassInfo(className);
-            foreach (var baseObject in ExtractBaseObjects(semanticModel, baseRecords, recordInfo))
-            {
-                yield return baseObject;
-            }
+            ExtractBaseObjects(semanticModel, baseRecords, recordInfo);
+
             AnalyzePropertiesFromRecordConstructor(recordNode.ParameterList, recordInfo);
             AnalyzePropertiesForObjectInfo(recordNode.Members, recordInfo!);
             AnalyzeFieldForObjectInfo(recordNode.Members, recordInfo);
@@ -160,7 +158,7 @@ public class ClassAnalyzer
         }
     }
 
-    private static IEnumerable<ObjectInfo> ExtractBaseObjects(SemanticModel semanticModel, IEnumerable<BaseTypeSyntax>? baseRecords, ClassInfo objectInfo)
+    private static void ExtractBaseObjects(SemanticModel semanticModel, IEnumerable<BaseTypeSyntax>? baseRecords, ClassInfo objectInfo)
     {
         if (baseRecords is not null && baseRecords.Any())
         {
@@ -170,12 +168,10 @@ public class ClassAnalyzer
                 if (symbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.TypeKind == TypeKind.Interface)
                 {
                     objectInfo.Implements(TypeSyntaxAnalyzer.GetTypeInfo(baseRecord.Type));
-                    yield return new InterfaceInfo(namedTypeSymbol.Name);
                 }
                 else
                 {
                     objectInfo.Inherits(TypeSyntaxAnalyzer.GetTypeInfo(baseRecord.Type));
-                    yield return new ClassInfo(baseRecord.Type.ToString());
                 }
             }
         }
@@ -194,7 +190,7 @@ public class ClassAnalyzer
 
     }
 
-    private IEnumerable<ObjectInfo> AnalyzeClasses(SyntaxNode root, SemanticModel semanticModel)
+    private IEnumerable<ClassInfo> AnalyzeClasses(SyntaxNode root, SemanticModel semanticModel)
     {
         foreach (var classNode in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
         {
@@ -207,10 +203,7 @@ public class ClassAnalyzer
             string className = classNode.Identifier.Text;
             var baseClasses = classNode.BaseList?.Types.OfType<BaseTypeSyntax>();
             var classInfo = new ClassInfo(className);
-            foreach (var baseObject in ExtractBaseObjects(semanticModel, baseClasses, classInfo))
-            {
-                yield return baseObject;
-            }
+            ExtractBaseObjects(semanticModel, baseClasses, classInfo);
             AnalyzeDependenciesOnConstructor(classNode, classInfo);
             AnalyzePropertiesForObjectInfo(classNode.Members, classInfo!);
             AnalyzeFieldForObjectInfo(classNode.Members, classInfo);

--- a/src/DotUML.CLI/Analyzers/ClassAnalyzer.cs
+++ b/src/DotUML.CLI/Analyzers/ClassAnalyzer.cs
@@ -169,7 +169,7 @@ public class ClassAnalyzer
                 var symbol = semanticModel.GetSymbolInfo(baseRecord.Type).Symbol;
                 if (symbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.TypeKind == TypeKind.Interface)
                 {
-                    objectInfo.Implements(namedTypeSymbol.Name);
+                    objectInfo.Implements(TypeSyntaxAnalyzer.GetTypeInfo(baseRecord.Type));
                     yield return new InterfaceInfo(namedTypeSymbol.Name);
                 }
                 else

--- a/src/DotUML.CLI/Analyzers/ClassAnalyzer.cs
+++ b/src/DotUML.CLI/Analyzers/ClassAnalyzer.cs
@@ -174,7 +174,7 @@ public class ClassAnalyzer
                 }
                 else
                 {
-                    objectInfo.Inherits(baseRecord.Type.ToString());
+                    objectInfo.Inherits(TypeSyntaxAnalyzer.GetTypeInfo(baseRecord.Type));
                     yield return new ClassInfo(baseRecord.Type.ToString());
                 }
             }

--- a/src/DotUML.CLI/Diagram/Models.cs
+++ b/src/DotUML.CLI/Diagram/Models.cs
@@ -102,7 +102,7 @@ public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
 {
     private TypeInfo? BaseClass { get; set; }
     private readonly List<DependencyInfo> _dependencies = new();
-    private readonly List<string> _interfaces = new();
+    private readonly List<TypeInfo> _interfaces = new();
 
     public override string GetObjectRepresentation()
     {
@@ -127,7 +127,7 @@ public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
         var sb = new IndentedStringBuilder();
         foreach (var @interface in _interfaces)
         {
-            sb.AppendLine($"{@interface} <|.. {SanitizedName}");
+            sb.AppendLine($"{@interface.SanitizedName} <|.. {SanitizedName}");
         }
         if (BaseClass is not null)
         {
@@ -150,7 +150,7 @@ public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
         _dependencies.Add(dependencyInfo);
     }
 
-    internal void Implements(string interfaceName)
+    internal void Implements(TypeInfo interfaceName)
     {
         _interfaces.Add(interfaceName);
     }

--- a/src/DotUML.CLI/Diagram/Models.cs
+++ b/src/DotUML.CLI/Diagram/Models.cs
@@ -100,7 +100,7 @@ public record EnumInfo(string Name) : ObjectInfo(Name)
 
 public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
 {
-    private string? BaseClass { get; set; }
+    private TypeInfo? BaseClass { get; set; }
     private readonly List<DependencyInfo> _dependencies = new();
     private readonly List<string> _interfaces = new();
 
@@ -129,9 +129,9 @@ public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
         {
             sb.AppendLine($"{@interface} <|.. {SanitizedName}");
         }
-        if (!string.IsNullOrEmpty(BaseClass))
+        if (BaseClass is not null)
         {
-            sb.AppendLine($"{BaseClass} <|-- {SanitizedName}");
+            sb.AppendLine($"{BaseClass.SanitizedName} <|-- {SanitizedName}");
         }
         foreach (var property in _properties.Where(p => p.Type is not PrimitiveType))
         {
@@ -155,9 +155,9 @@ public record ClassInfo(string Name) : ObjectInfo(Name), IHaveRelationships
         _interfaces.Add(interfaceName);
     }
 
-    internal void Inherits(string baseClassName)
+    internal void Inherits(TypeInfo baseClass)
     {
-        BaseClass = baseClassName;
+        BaseClass = baseClass;
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `ClassAnalyzer` and `Models` classes in the `DotUML.CLI` project. The main goal is to improve type safety and consistency by replacing `string` types with `TypeInfo` for class and interface names. Additionally, some methods have been refactored for better clarity and efficiency.

Improvements to type safety and consistency:

* [`src/DotUML.CLI/Analyzers/ClassAnalyzer.cs`](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L137-R137): Changed return type from `ObjectInfo` to `ClassInfo` in the `AnalyzeRecords` and `AnalyzeClasses` methods. [[1]](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L137-R137) [[2]](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L197-R193)
* [`src/DotUML.CLI/Analyzers/ClassAnalyzer.cs`](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L163-R161): Modified `ExtractBaseObjects` to return void and updated its logic to use `TypeInfo` instead of `string` for class and interface names. [[1]](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L163-R161) [[2]](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L172-R174)

Refactoring for clarity and efficiency:

* [`src/DotUML.CLI/Analyzers/ClassAnalyzer.cs`](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L150-R151): Removed unnecessary `yield return` statements to prevent duplicates in the `AnalyzeRecords` and `AnalyzeClasses` methods. [[1]](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L150-R151) [[2]](diffhunk://#diff-d23f5557297dafa103ed3a14443a2c9b13c7976af549332989e8f0c19de57139L210-R206)

Updates to `Models` class:

* [`src/DotUML.CLI/Diagram/Models.cs`](diffhunk://#diff-db2095ae3d673c220d6954c823a76c74afb2392732120f37f4274ae3a0c24b40L103-R105): Updated `ClassInfo` to use `TypeInfo` for `BaseClass` and `_interfaces` properties.
* [`src/DotUML.CLI/Diagram/Models.cs`](diffhunk://#diff-db2095ae3d673c220d6954c823a76c74afb2392732120f37f4274ae3a0c24b40L130-R134): Modified methods to reflect the change from `string` to `TypeInfo`, including `GetRelationshipRepresentation`, `Implements`, and `Inherits`. [[1]](diffhunk://#diff-db2095ae3d673c220d6954c823a76c74afb2392732120f37f4274ae3a0c24b40L130-R134) [[2]](diffhunk://#diff-db2095ae3d673c220d6954c823a76c74afb2392732120f37f4274ae3a0c24b40L153-R160)

Closes #31 